### PR TITLE
Corrected an issue where a data import was expected to have a parent.

### DIFF
--- a/code/importers/JsonDataTransformer.php
+++ b/code/importers/JsonDataTransformer.php
@@ -49,7 +49,9 @@ class JsonDataTransformer implements ExternalContentTransformer
         }
         
         // set now, so that later functionality can overwrite. 
-        $newObject->ParentID = $parentObject->ID;
+        if(!($newObject instanceof DataImport)) {
+            $newObject->ParentID = $parentObject->ID;
+        }
         $doPublish = false;
         
         $fixedProperties = $source->ImportProperties->getValues();


### PR DESCRIPTION
This resolves an error from appearing when attempting to import, which says the following because a data import doesn't actually have a parent.

> the method 'parent' does not exist on 'DataImport'
